### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,17 @@ Vimbed
 
 Vimbed is a Vim plugin for embedding Vim in other programs. Run Vim in the background using Vimbed to ease communication with external processes.
 
-##Projects that use Vimbed
+## Projects that use Vimbed
 - [Athame](http://github.com/ardagnir/athame) patches GNU Readline to embed Vim in bash, gdb, python, etc. Athame can also be used to patch Zsh to add Vim.
 - [Pterosaur](http://github.com/ardagnir/pterosaur) embeds Vim in Firefox textboxes. *(No longer maintained)*
 - [Chalcogen](http://github.com/ardagnir/chalcogen) embeds Vim in the Atom editor. *(Experimental. Not maintained)*
 
-##Requirements
+## Requirements
 - Vimbed requires Vim with +clientserver.
 - Vimbed works best in GNU/Linux.
 - Vimbed also works in OSX, but doing so requires XQuartz. *(This is a requirement of vim's +clientserver functionality.)*
 
-##Installation
+## Installation
 Install vimbed with your favorite plugin-manager. If you use pathogen:
 
     cd ~/.vim/bundle
@@ -21,8 +21,8 @@ Install vimbed with your favorite plugin-manager. If you use pathogen:
 
 Note that vimbed won't be very useful without another process to communicate with.
 
-##API
+## API
 Coming eventually. Until then, see Athame, Pterosaur, and Chalcogen for examples.
 
-##License
+## License
 AGPL v3


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
